### PR TITLE
Address deprecation of referrer

### DIFF
--- a/src/main/java/org/htmlunit/csp/Policy.java
+++ b/src/main/java/org/htmlunit/csp/Policy.java
@@ -19,6 +19,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
@@ -282,6 +283,15 @@ public final class Policy {
                     wasDupe = true;
                 }
                 newDirective = new Directive(values);
+                break;
+            }
+            case "referrer": {
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/referrer
+                directiveErrorConsumer.add(Severity.Warning,
+                        "The referrer directive has been deprecated in favor of the Referrer-Policy header",
+                        -1);
+                // We don't currently handle it further than this.
+                newDirective = new Directive(Collections.emptyList());
                 break;
             }
             case "report-uri": {

--- a/src/test/java/org/htmlunit/csp/ParserTest.java
+++ b/src/test/java/org/htmlunit/csp/ParserTest.java
@@ -57,6 +57,14 @@ public class ParserTest extends TestBase {
     }
 
     @Test
+    void referrerDirectiveShouldWarn() {
+        serializesTo(
+                "referrer no-referrer", "referrer",
+                e(Policy.Severity.Warning, "The referrer directive has been deprecated in favor of the Referrer-Policy header", 0, -1)
+        );
+    }
+
+    @Test
     public void simpleCases() {
         Policy p;
 


### PR DESCRIPTION
- Policy > Updated with appropriate deprecation notice and handling.
- ParserTest > Updated to assert the new behavior.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/referrer

Note: I didn't not add a new directive type to parse referrer further.

Related to: https://github.com/zaproxy/zaproxy/issues/8077 and https://github.com/zaproxy/zap-extensions/pull/4950