### PR TITLE
Add wasm-unsafe-eval source expression directive

### DIFF
--- a/src/main/java/org/htmlunit/csp/Constants.java
+++ b/src/main/java/org/htmlunit/csp/Constants.java
@@ -36,7 +36,8 @@ public final class Constants {
     /** UNQUOTED_KEYWORD_PATTERN. */
     public static final Pattern UNQUOTED_KEYWORD_PATTERN
                 = Pattern.compile("^(?:self|unsafe-inline|unsafe-eval|unsafe-redirect"
-                        + "|none|strict-dynamic|unsafe-hashes|report-sample|unsafe-allow-redirects)$");
+                        + "|none|strict-dynamic|unsafe-hashes|report-sample|unsafe-allow-redirects|"
+                        + "wasm-unsafe-eval)$");
 
     // port-part constants
     /** WILDCARD_PORT = -200. */

--- a/src/main/java/org/htmlunit/csp/directive/SourceExpressionDirective.java
+++ b/src/main/java/org/htmlunit/csp/directive/SourceExpressionDirective.java
@@ -31,12 +31,15 @@ public class SourceExpressionDirective extends HostSourceDirective {
     private static final String UNSAFE_ALLOW_REDIRECTS = "'unsafe-allow-redirects'";
     private static final String UNSAFE_EVAL = "'unsafe-eval'";
     private static final String UNSAFE_HASHES = "'unsafe-hashes'";
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution
+    private static final String WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
     private boolean unsafeInline_;
     private boolean unsafeEval_;
     private boolean strictDynamic_;
     private boolean unsafeHashes_;
     private boolean reportSample_;
     private boolean unsafeAllowRedirects_;
+    private boolean unsafeWasm_;
 
     // In practice, these are probably small enough for Lists to be faster than LinkedHashSets
     private final List<Nonce> nonces_ = new ArrayList<>();
@@ -82,6 +85,14 @@ public class SourceExpressionDirective extends HostSourceDirective {
                     }
                     else {
                         errors.add(Policy.Severity.Warning, "Duplicate source-expression 'unsafe-hashes'", index);
+                    }
+                    break;
+                case WASM_UNSAFE_EVAL:
+                    if (!unsafeWasm_) {
+                        unsafeWasm_ = true;
+                    }
+                    else {
+                        errors.add(Policy.Severity.Warning, "Duplicate source-expression " + WASM_UNSAFE_EVAL, index);
                     }
                     break;
                 case REPORT_SAMPLE:

--- a/src/test/java/org/htmlunit/csp/ParserTest.java
+++ b/src/test/java/org/htmlunit/csp/ParserTest.java
@@ -532,6 +532,11 @@ public class ParserTest extends TestBase {
             );
 
             roundTrips(
+                    "script-src 'wasm-unsafe-eval' 'WASM-UNSAFE-EVAL'",
+                    e(Policy.Severity.Warning, "Duplicate source-expression 'wasm-unsafe-eval'", 0, 1)
+            );
+
+            roundTrips(
                     "default-src 'unsafe-hashes' 'UNSAFE-HASHES'",
                     e(Policy.Severity.Warning, "Duplicate source-expression 'unsafe-hashes'", 0, 1)
             );


### PR DESCRIPTION
- Constants > Add to UNQUOTED_KEYWORD_PATTERN.
- ParserTest > Add tests for duplicate source-expression.
- SourceExpressionDirective > Add wasm-unsafe-eval handling.

https://github.com/shapesecurity/salvation/issues/260
