### PR TITLE
Add allowsWildcardPolicyNames check for trusted-types

### DIFF
--- a/src/main/java/org/htmlunit/csp/Policy.java
+++ b/src/main/java/org/htmlunit/csp/Policy.java
@@ -465,6 +465,16 @@ public class Policy {
         return Optional.ofNullable(trustedTypes_);
     }
 
+    /**
+     * Indicates if wildcard policy names are permitted in the trusted-types directive.
+     * When true, any policy name is allowed, which may reduce security.
+     *
+     * @return true if wildcard policy names (*) are permitted, false if not present or not permitted
+     */
+    public boolean allowsWildcardPolicyNames() {
+        return trustedTypes_ != null && trustedTypes_.allowsWildcardPolicyNames();
+    }
+
     public Optional<RequireTrustedTypesForDirective> requireTrustedTypesFor() {
         return Optional.ofNullable(requireTrustedTypesFor_);
     }


### PR DESCRIPTION
### AI Disclosure

Cursor IDE was used in the preparation of these changes.

---

Fixes #4 
Supersedes #9

---

# Add Wildcard Policy Names Detection and Enhanced Validation for Trusted Types Directive

## Summary

Adds detection and warnings for wildcard policy names (`*`) in the `trusted-types` directive, plus validation for redundant combinations and edge cases.

## Changes

### New API

- `TrustedTypesDirective.allowsWildcardPolicyNames()` - Check if wildcard policy names are permitted
- `Policy.allowsWildcardPolicyNames()` - Same check at Policy level

### New Warnings

- Security warning when `*` is used (reduces security)
- Redundancy warning when policy names are combined with `*`
- Warning for empty `trusted-types` directive
- Warning when `allow-duplicates` is redundant with wildcard
- Warning when `allow-duplicates` has no effect (no policy names or wildcard)

### Implementation

Follows the same patterns as other directives (e.g., `HostSourceDirective` for wildcard handling). All warnings are generated during parsing via `DirectiveErrorConsumer`.

## Files Changed

- `TrustedTypesDirective.java` - Added method and validation logic
- `Policy.java` - Exposed `allowsWildcardPolicyNames()` method
- `TrustedTypesTest.java` - Added comprehensive tests and fixed existing test

## Backward Compatibility

✅ Fully backward compatible - all changes are additive (new methods/warnings only).
