### PR TITLE
Add addPolicyName/removePolicyName methods for TrustedTypesDirective

### DIFF
--- a/src/main/java/org/htmlunit/csp/Directive.java
+++ b/src/main/java/org/htmlunit/csp/Directive.java
@@ -65,6 +65,10 @@ public class Directive {
         values_ = copy;
     }
 
+    protected void removeValueExact(final String value) {
+        values_.remove(value);
+    }
+
     @FunctionalInterface
     public interface DirectiveErrorConsumer {
         /** ignored. */
@@ -73,5 +77,22 @@ public class Directive {
         void add(Policy.Severity severity, String message,
                 int valueIndex); // index = -1 for errors not pertaining to a value
 
+    }
+
+    /** ManipulationErrorConsumer. */
+    @FunctionalInterface
+    public interface ManipulationErrorConsumer {
+        /** ignored. */
+        ManipulationErrorConsumer ignored = (severity, message) -> { };
+
+        void add(Severity severity, String message);
+
+        /** Severity. */
+        enum Severity {
+            /** Info. */
+            Info,
+            /** Warning. */
+            Warning
+        }
     }
 }

--- a/src/main/java/org/htmlunit/csp/directive/TrustedTypesDirective.java
+++ b/src/main/java/org/htmlunit/csp/directive/TrustedTypesDirective.java
@@ -188,4 +188,32 @@ public class TrustedTypesDirective extends Directive {
     public List<String> getPolicyNames_() {
         return Collections.unmodifiableList(policyNames_);
     }
+
+    /**
+     * Add a policy name.
+     * @param policyName the policy name to add
+     * @param errors the error consumer
+     */
+    public void addPolicyName(final String policyName, final ManipulationErrorConsumer errors) {
+        if (!TT_POLICY_NAME_PATTERN.matcher(policyName).matches()) {
+            throw new IllegalArgumentException("Invalid policy name: " + policyName);
+        }
+        // Policy names are case-sensitive per browser behavior
+        if (policyNames_.contains(policyName)) {
+            errors.add(ManipulationErrorConsumer.Severity.Warning, "Duplicate policy name " + policyName);
+            return;
+        }
+        policyNames_.add(policyName);
+        addValue(policyName);
+    }
+
+    /**
+     * Remove a policy name.
+     * @param policyName the policy name to remove
+     */
+    public void removePolicyName(final String policyName) {
+        // Policy names are case-sensitive per browser behavior
+        policyNames_.remove(policyName);
+        removeValueExact(policyName);
+    }
 }


### PR DESCRIPTION
## Summary
- Port the remaining manipulation API from https://github.com/shapesecurity/salvation/pull/273 that was not included in 34b5635
- Add `ManipulationErrorConsumer` interface and `removeValueExact()` to `Directive` base class
- Add `addPolicyName()` and `removePolicyName()` to `TrustedTypesDirective`
- Add 8 new tests covering validation, duplicate warnings, case sensitivity, special characters, round-trip serialization, and edge cases