### PR TITLE
feat: warn meta-invalid CSP directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Policy policy = Policy.parseSerializedCSP(policyText, (severity, message, direct
 });
 ```
 
+For a policy from a `<meta http-equiv="Content-Security-Policy" content="...">` element, pass `true` as the third argument so that `frame-ancestors`, `sandbox`, and `report-uri` produce warnings (those directives are ignored when delivered via meta):
+
+```java
+Policy metaPolicy = Policy.parseSerializedCSP(metaContent, consumer, true);
+```
+
 ### Query a Policy
 
 The high-level querying methods allow you to specify whatever relevant information you have. The missing information will be assumed to be worst-case - that is, these methods will return `true` only if any object which matches the provided characteristics would be allowed, regardless of its other characteristics. 

--- a/src/main/java/org/htmlunit/csp/Policy.java
+++ b/src/main/java/org/htmlunit/csp/Policy.java
@@ -99,8 +99,10 @@ public final class Policy {
     private final EnumMap<FetchDirectiveKind, SourceExpressionDirective> fetchDirectives_
                     = new EnumMap<>(FetchDirectiveKind.class);
 
-    private Policy() {
-        // pass
+    private final boolean deliveredViaMeta_;
+
+    private Policy(final boolean deliveredViaMeta) {
+        deliveredViaMeta_ = deliveredViaMeta;
     }
 
     /**
@@ -149,11 +151,8 @@ public final class Policy {
     /**
      * Parses a single serialized CSP string into a {@link Policy}.
      * <p>
-     * Implements the
-     * <a href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse a
-     * serialized CSP</a> algorithm. The input must be an ASCII string and must not
-     * contain commas; for comma-separated CSP lists use
-     * {@link #parseSerializedCSPList(String, PolicyListErrorConsumer)}.
+     * Equivalent to {@link #parseSerializedCSP(String, PolicyErrorConsumer, boolean)}
+     * with {@code deliveredViaMeta} set to {@code false}.
      * </p>
      *
      * @param serialized the serialized CSP string to parse (must not contain commas)
@@ -164,6 +163,39 @@ public final class Policy {
      *         or contains a comma
      */
     public static Policy parseSerializedCSP(final String serialized, final PolicyErrorConsumer policyErrorConsumer) {
+        return parseSerializedCSP(serialized, policyErrorConsumer, false);
+    }
+
+    /**
+     * Parses a single serialized CSP string into a {@link Policy}.
+     * <p>
+     * Implements the
+     * <a href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse a
+     * serialized CSP</a> algorithm. The input must be an ASCII string and must not
+     * contain commas; for comma-separated CSP lists use
+     * {@link #parseSerializedCSPList(String, PolicyListErrorConsumer)}.
+     * </p>
+     * <p>
+     * When {@code deliveredViaMeta} is {@code true}, warnings are emitted for
+     * {@code frame-ancestors}, {@code sandbox}, and {@code report-uri}, which are
+     * ignored when a policy is delivered via a {@code meta} element.
+     * </p>
+     *
+     * @param serialized the serialized CSP string to parse (must not contain commas)
+     * @param policyErrorConsumer a consumer that receives any errors or warnings
+     *        encountered during parsing
+     * @param deliveredViaMeta {@code true} if the policy was delivered via a
+     *        {@code meta} element rather than an HTTP header
+     * @return the parsed {@link Policy}
+     * @throws IllegalArgumentException if {@code serialized} contains non-ASCII characters
+     *         or contains a comma
+     * @see <a href="https://w3c.github.io/webappsec-csp/#meta-element">CSP meta element</a>
+     * @see <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">
+     *      HTML Content security policy state</a>
+     * @since 5.4.0
+     */
+    public static Policy parseSerializedCSP(final String serialized, final PolicyErrorConsumer policyErrorConsumer,
+            final boolean deliveredViaMeta) {
         // "A serialized CSP is an ASCII string", and browsers do in fact reject CSPs which contain non-ASCII characters
         enforceAscii(serialized);
         if (serialized.contains(",")) {
@@ -178,7 +210,7 @@ public final class Policy {
                 (Severity severity, String message, int valueIndex) ->
                         policyErrorConsumer.add(severity, message, index[0], valueIndex);
 
-        final Policy policy = new Policy();
+        final Policy policy = new Policy(deliveredViaMeta);
 
         // https://infra.spec.whatwg.org/#strictly-split
         for (final String token : serialized.split(";")) {
@@ -267,6 +299,10 @@ public final class Policy {
                 // https://w3c.github.io/webappsec-csp/#directive-frame-ancestors
                 // TODO contemplate warning for paths, which are always ignored: frame-ancestors only matches
                 // against origins: https://w3c.github.io/webappsec-csp/#frame-ancestors-navigation-response
+                if (deliveredViaMeta_) {
+                    directiveErrorConsumer.add(Severity.Warning,
+                            "The frame-ancestors directive is ignored when delivered via a meta element", -1);
+                }
                 final FrameAncestorsDirective frameAncestorsDirective
                         = new FrameAncestorsDirective(values, directiveErrorConsumer);
                 if (frameAncestors_ == null) {
@@ -348,6 +384,10 @@ public final class Policy {
                 // https://w3c.github.io/webappsec-csp/#directive-report-uri
                 directiveErrorConsumer.add(Severity.Warning,
                         "The report-uri directive has been deprecated in favor of the new report-to directive", -1);
+                if (deliveredViaMeta_) {
+                    directiveErrorConsumer.add(Severity.Warning,
+                            "The report-uri directive is ignored when delivered via a meta element", -1);
+                }
 
                 final ReportUriDirective reportUriDirective = new ReportUriDirective(values, directiveErrorConsumer);
                 if (reportUri_ == null) {
@@ -361,6 +401,10 @@ public final class Policy {
 
             case "sandbox":
                 // https://w3c.github.io/webappsec-csp/#directive-sandbox
+                if (deliveredViaMeta_) {
+                    directiveErrorConsumer.add(Severity.Warning,
+                            "The sandbox directive is ignored when delivered via a meta element", -1);
+                }
                 final SandboxDirective sandboxDirective = new SandboxDirective(values, directiveErrorConsumer);
                 if (sandbox_ == null) {
                     sandbox_ = sandboxDirective;
@@ -496,6 +540,18 @@ public final class Policy {
      */
     public boolean blockAllMixedContent() {
         return blockAllMixedContent_;
+    }
+
+    /**
+     * Returns whether this policy was parsed as delivered via a {@code meta} element.
+     *
+     * @return {@code true} if {@link #parseSerializedCSP(String, PolicyErrorConsumer, boolean)}
+     *         was called with {@code deliveredViaMeta} set to {@code true}
+     * @see <a href="https://w3c.github.io/webappsec-csp/#meta-element">CSP meta element</a>
+     * @since 5.4.0
+     */
+    public boolean deliveredViaMeta() {
+        return deliveredViaMeta_;
     }
 
     /**

--- a/src/test/java/org/htmlunit/csp/ParserTest.java
+++ b/src/test/java/org/htmlunit/csp/ParserTest.java
@@ -15,6 +15,7 @@
 package org.htmlunit.csp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -688,19 +689,66 @@ public class ParserTest extends TestBase {
         assertThrows(IllegalArgumentException.class, () -> Policy.parseSerializedCSP("a ,", PolicyErrorConsumer.ignored));
     }
 
+    @Test
+    public void deliveredViaMetaFlag() {
+        assertFalse(Policy.parseSerializedCSP("script-src 'none'", ThrowIfPolicyError).deliveredViaMeta());
+        assertTrue(Policy.parseSerializedCSP("script-src 'none'", ThrowIfPolicyError, true).deliveredViaMeta());
+        assertFalse(Policy.parseSerializedCSP("script-src 'none'", ThrowIfPolicyError, false).deliveredViaMeta());
+    }
+
+    @Test
+    public void metaInvalidDirectivesWarn() {
+        serializesToMeta(
+                "frame-ancestors 'none'", "frame-ancestors 'none'",
+                e(Policy.Severity.Warning, "The frame-ancestors directive is ignored when delivered via a meta element", 0, -1)
+        );
+        serializesToMeta(
+                "sandbox", "sandbox",
+                e(Policy.Severity.Warning, "The sandbox directive is ignored when delivered via a meta element", 0, -1)
+        );
+        serializesToMeta(
+                "report-uri http://example.com", "report-uri http://example.com",
+                e(Policy.Severity.Warning, "The report-uri directive has been deprecated in favor of the new report-to directive", 0, -1),
+                e(Policy.Severity.Warning, "The report-uri directive is ignored when delivered via a meta element", 0, -1)
+        );
+        serializesToMeta(
+                "script-src 'none'; frame-ancestors 'self'; sandbox allow-scripts; report-uri /csp",
+                "script-src 'none'; frame-ancestors 'self'; sandbox allow-scripts; report-uri /csp",
+                e(Policy.Severity.Warning, "The frame-ancestors directive is ignored when delivered via a meta element", 1, -1),
+                e(Policy.Severity.Warning, "The sandbox directive is ignored when delivered via a meta element", 2, -1),
+                e(Policy.Severity.Warning, "The report-uri directive has been deprecated in favor of the new report-to directive", 3, -1),
+                e(Policy.Severity.Warning, "The report-uri directive is ignored when delivered via a meta element", 3, -1)
+        );
+        // Fetch directives remain valid via meta
+        serializesToMeta("script-src 'none'; default-src 'self'", "script-src 'none'; default-src 'self'");
+        // Not via meta: no meta warnings
+        roundTrips("frame-ancestors 'none'");
+        roundTrips("sandbox");
+    }
+
     private static void roundTrips(final String input, final PolicyError... errors) {
         serializesTo(input, input, errors);
     }
 
     private static void serializesTo(final String input, final String output, final PolicyError... errors) {
+        serializesTo(input, output, false, errors);
+    }
+
+    private static void serializesToMeta(final String input, final String output, final PolicyError... errors) {
+        serializesTo(input, output, true, errors);
+    }
+
+    private static void serializesTo(final String input, final String output, final boolean deliveredViaMeta,
+            final PolicyError... errors) {
         final ArrayList<PolicyError> observedErrors = new ArrayList<>();
         final Policy.PolicyErrorConsumer consumer = (severity, message, directiveIndex, valueIndex) -> observedErrors.add(e(severity, message, directiveIndex, valueIndex));
-        final Policy policy = Policy.parseSerializedCSP(input, consumer);
+        final Policy policy = Policy.parseSerializedCSP(input, consumer, deliveredViaMeta);
         assertEquals(errors.length, observedErrors.size());
         for (int i = 0; i < errors.length; ++i) {
             assertEquals(errors[i], observedErrors.get(i));
         }
         assertEquals(output, policy.toString());
+        assertEquals(deliveredViaMeta, policy.deliveredViaMeta());
     }
 
     /**


### PR DESCRIPTION
frame-ancestors, sandbox, and report-uri are ignored when delivered via meta; flag via parseSerializedCSP(..., true).